### PR TITLE
Need some suggestions to deploy CRUD methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # loopback-connector-couchbase3
-without N1QL
+
+This is a Couchbase connector node module for [Loopback](http://loopback.io/) with [loopback-datasource-juggler](https://github.com/strongloop/loopback-datasource-juggler). Without N1QL for now.
+
+
+### Test
+
+```bash
+$ mocha test 
+```
+
+For detail information:
+
+```bash
+$ DEBUG=loopback:connector:couchbase3 mocha test 
+```

--- a/README.md
+++ b/README.md
@@ -14,3 +14,8 @@ For detail information:
 ```bash
 $ DEBUG=loopback:connector:couchbase3 mocha test 
 ```
+
+### TODO
+
+- Deploy ```Couchbase.prototype.count``` which is relied by ```Couchbase.prototype.exists```
+- Deploy ```Couchbase.prototype.all``` which is relied by ```Couchbase.prototype.find```

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Remove document by given document ID.
 
 ### Test
 
+Run your CouchBase Server at 127.0.0.1 first.
+
 ```bash
 $ mocha test 
 ```

--- a/README.md
+++ b/README.md
@@ -2,6 +2,23 @@
 
 This is a Couchbase connector node module for [Loopback](http://loopback.io/) with [loopback-datasource-juggler](https://github.com/strongloop/loopback-datasource-juggler). Without N1QL for now.
 
+### CRUD methods
+
+- Insert
+
+For document ```insert``` only, and will not update a existed one. If there is a document with same ID, a exception will be thrown.
+
+- Find
+
+Find document by given document ID.
+
+- Update
+
+Update a existed document by giving a document ID, or create a new one if there is no such a document.
+
+- Remove
+
+Remove document by given document ID.
 
 ### Test
 
@@ -15,7 +32,3 @@ For detail information:
 $ DEBUG=loopback:connector:couchbase3 mocha test 
 ```
 
-### TODO
-
-- Deploy ```Couchbase.prototype.count``` which is relied by ```Couchbase.prototype.exists```
-- Deploy ```Couchbase.prototype.all``` which is relied by ```Couchbase.prototype.find```

--- a/lib/couchbase3.js
+++ b/lib/couchbase3.js
@@ -203,12 +203,64 @@ Couchbase.prototype.save = function (model, data, callback) {
  * Check if a model instance exists by id
  */
 Couchbase.prototype.exists = function (model, id, callback) {
+  var self = this;
+  debug("Couchbase.EXISTS: " + id);
+
+  if (callback == null) {
+    callback = noop;
+  }
+
+  // Handle with promise.
+  var promise;
+  var resolved = function(res) {
+    return callback(null, res);
+  };
+
+  promise = promise.then(function(bucket) {
+    bucket.get(id, function(err, result) {
+      if (err) {
+        debug('find exists failed');
+        return callback(err,null);
+      }
+      
+      debug('find exists successfully.');
+      return true;
+    });
+  });
+
+  return promise.then(resolved, callback);
 };
 
 /**
  * Find a model instance by id
  */
 Couchbase.prototype.find = function find(model, id, callback) {
+  var self = this;
+  debug("Couchbase.Find: " + id);
+
+  if (callback == null) {
+    callback = noop;
+  }
+
+  // Handle with promise.
+  var promise;
+  var resolved = function(res) {
+    return callback(null, res);
+  };
+
+  promise = promise.then(function(bucket) {
+    bucket.get(id, function(err, result) {
+      if (err) {
+        debug('Find failed');
+        return callback(err,null);
+      }
+      
+      debug('Find successfully.');
+      return result.value;
+    });
+  });
+
+  return promise.then(resolved, callback);
 };
 
 /**
@@ -227,6 +279,7 @@ Couchbase.prototype.destroy = function destroy(model, id, callback) {
  * Query model instances by the filter
  */
 Couchbase.prototype.all = function all(model, filter, callback) {
+  console.log("all being used.")
 };
 
 /**
@@ -240,6 +293,7 @@ Couchbase.prototype.destroyAll = function destroyAll(model, callback) {
  * Count the model instances by the where criteria
  */
 Couchbase.prototype.count = function count(model, callback, where) {
+  console.log("count being used.")
 };
 
 /**

--- a/lib/couchbase3.js
+++ b/lib/couchbase3.js
@@ -130,7 +130,7 @@ Couchbase.prototype.disconnect = function(callback) {
   // The cached promise.
   promise = this._connection;
   if (promise == null) {
-    debug('No connections to be disconnected');
+    debug('No connections.');
     return Promise.resolve(true).then(resolved, callback);
   }
   // Disconnect.
@@ -144,4 +144,106 @@ Couchbase.prototype.disconnect = function(callback) {
   this.bucket = null;
   this.cluster = null;
   return promise.then(resolved, callback);
+};
+
+/**
+ * Create a new model instance for the given data
+ * @param {String} model The model name
+ * @param {Object} data The model data
+ * @param {Function} [callback] The callback function
+ */
+Couchbase.prototype.create = function (model, data, callback) {
+  var self = this;
+  debug("Couchbase.CREATE: " + JSON.stringify([model, data]));
+
+  if (callback == null) {
+    callback = noop;
+  }
+
+  // Handle with promise.
+  var promise;
+  var resolved = function(res) {
+    return callback(null, res);
+  };
+
+  // The cached promise.
+  promise = this._connection;
+  if (promise == null) {
+    debug('No connections. Try to connect...');
+    self.connect(callback);
+    promise = this._connection;
+  }
+
+  //Data
+  var id = self.getIdValue(model, data);
+
+  // Insert.
+  promise = promise.then(function(bucket) {
+    bucket.upsert(id, data,function(err, result) {
+      if (err) {
+        debug('create failed');
+        return callback(err,null);
+      }
+      
+      debug('create successfully.');
+      return result.value;
+    });
+  });
+
+  return promise.then(resolved, callback);
+};
+
+/**
+ * Save a model instance
+ */
+Couchbase.prototype.save = function (model, data, callback) {
+};
+
+/**
+ * Check if a model instance exists by id
+ */
+Couchbase.prototype.exists = function (model, id, callback) {
+};
+
+/**
+ * Find a model instance by id
+ */
+Couchbase.prototype.find = function find(model, id, callback) {
+};
+
+/**
+ * Update a model instance or create a new model instance if it doesn't exist
+ */
+Couchbase.prototype.updateOrCreate = function updateOrCreate(model, data, callback) {
+};
+
+/**
+ * Delete a model instance by id
+ */
+Couchbase.prototype.destroy = function destroy(model, id, callback) {
+};
+
+/**
+ * Query model instances by the filter
+ */
+Couchbase.prototype.all = function all(model, filter, callback) {
+};
+
+/**
+ * Delete all model instances
+ */
+Couchbase.prototype.destroyAll = function destroyAll(model, callback) {
+
+};
+
+/**
+ * Count the model instances by the where criteria
+ */
+Couchbase.prototype.count = function count(model, callback, where) {
+};
+
+/**
+ * Update the attributes for a model instance by id
+ */
+Couchbase.prototype.updateAttributes = function updateAttrs(model, id, data, callback) {
 };

--- a/lib/couchbase3.js
+++ b/lib/couchbase3.js
@@ -39,7 +39,7 @@ exports.initialize = function initializeDataSource(dataSource, callback) {
     settings.bucket.name = 'default';
   }
   if (settings.bucket.password == null) {
-    settings.bucket.password = null;
+    settings.bucket.password = '';
   }
 
   dataSource.connector = new Couchbase(settings, dataSource);
@@ -47,6 +47,7 @@ exports.initialize = function initializeDataSource(dataSource, callback) {
   // Though not mentioned, initialize() is expected to connect().
   // @see dataSource.setup()
   if (callback) {
+    debug('Initialize and connect');
     dataSource.connector.connect(callback);
   }
 };
@@ -75,6 +76,7 @@ util.inherits(Couchbase, Connector);
  * @param {Error} err The error object
  */
 Couchbase.prototype.connect = function(callback) {
+  debug('Ready to connect');
   if (callback == null) {
     callback = noop;
   }
@@ -88,6 +90,7 @@ Couchbase.prototype.connect = function(callback) {
   // The cached promise.
   promise = this._connection;
   if (promise != null) {
+    debug('connection already established');
     promise.then(resolved, callback);
     return promise;
   }
@@ -115,7 +118,7 @@ Couchbase.prototype.connect = function(callback) {
  * Disconnect from Couchbase
  */
 Couchbase.prototype.disconnect = function(callback) {
-  debug('disconnect');
+  debug('Ready to disconnect');
   if (callback == null) {
     callback = noop;
   }
@@ -127,11 +130,13 @@ Couchbase.prototype.disconnect = function(callback) {
   // The cached promise.
   promise = this._connection;
   if (promise == null) {
+    debug('No connections to be disconnected');
     return Promise.resolve(true).then(resolved, callback);
   }
   // Disconnect.
   promise = promise.then(function(bucket) {
     bucket.disconnect();
+    debug('disconnected');
     return true;
   });
   // Cleanup.

--- a/lib/couchbase3.js
+++ b/lib/couchbase3.js
@@ -170,27 +170,167 @@ Couchbase.prototype.create = function (model, data, callback) {
   promise = this._connection;
   if (promise == null) {
     debug('No connections. Try to connect...');
-    self.connect(callback);
-    promise = this._connection;
+    promise = self.connect(callback);
   }
 
-  //Data
+  //bucket id
   var id = self.getIdValue(model, data);
 
-  // Insert.
   promise = promise.then(function(bucket) {
-    bucket.upsert(id, data,function(err, result) {
-      if (err) {
-        debug('create failed');
-        return callback(err,null);
-      }
-      
-      debug('create successfully.');
-      return result.value;
+    Promise.promisifyAll(bucket);
+    return bucket.insertAsync(id,data).then(function(result) {
+      debug('Create successfully.');
+      return true;
     });
+  }).catch(function(e) {
+    debug('Create failed:',e);
+    return callback(e,null);
   });
 
   return promise.then(resolved, callback);
+};
+
+/**
+ * Query model instances by the filter
+ */
+Couchbase.prototype.all = function all(model, filter, callback) {
+  var self = this;
+  debug("Couchbase.Find: ",filter);
+
+  if (callback == null) {
+    callback = noop;
+  }
+
+  // Handle with promise.
+  var promise;
+  var resolved = function(res) {
+    return callback(null, res);
+  };
+
+  //bucket id
+  var id = self.getIdValue(model, filter);
+
+  //The cached promise.
+  promise = this._connection;
+  if (promise == null) {
+    debug('No connections. Try to connect...');
+    promise = self.connect(callback);
+  }
+
+  promise = promise.then(function(bucket) {
+    Promise.promisifyAll(bucket);
+    return bucket.getAsync(id).then(function(result) {
+      debug('Find successfully.');
+      return result.value;
+    });
+  }).catch(function(e) {
+    debug('Find failed',e);
+    return callback(e,null);
+  });
+      
+  return promise.then(resolved, callback);
+};
+
+/**
+ * Update a model instance or create a new model instance if it doesn't exist
+ */
+Couchbase.prototype.update = function update(model, where, data, callback) {
+  var self = this;
+  debug("Couchbase.UPDATE: " + JSON.stringify([model, data]));
+
+  if (callback == null) {
+    callback = noop;
+  }
+
+  // Handle with promise.
+  var promise;
+  var resolved = function(res) {
+    return callback(null, res);
+  };
+
+  // The cached promise.
+  promise = this._connection;
+  if (promise == null) {
+    debug('No connections. Try to connect...');
+    promise = self.connect(callback);
+  }
+
+  //bucket id
+  var id = self.getIdValue(model, where);
+
+  promise = promise.then(function(bucket) {
+    Promise.promisifyAll(bucket);
+    return bucket.upsertAsync(id,data).then(function(result) {
+      debug('Update successfully.');
+      return true;
+    });
+  }).catch(function(e) {
+    debug('Update failed:',e);
+    return callback(e,null);
+  });
+
+  return promise.then(resolved, callback);
+};
+
+/**
+ * Delete all model instances
+ */
+Couchbase.prototype.destroyAll = function destroyAll(model, id, callback) {
+  var self = this;
+  debug("Couchbase.DESTROY: " + JSON.stringify([model]));
+
+  if (callback == null) {
+    callback = noop;
+  }
+
+  // Handle with promise.
+  var promise;
+  var resolved = function(res) {
+    return callback(null, res);
+  };
+
+  // The cached promise.
+  promise = this._connection;
+  if (promise == null) {
+    debug('No connections. Try to connect...');
+    promise = self.connect(callback);
+  }
+
+  //bucket id
+  var id = self.getIdValue(model, id);
+  
+  promise = promise.then(function(bucket) {
+    Promise.promisifyAll(bucket);
+    return bucket.removeAsync(id).then(function(result) {
+      debug('Destroy successfully.');
+      return true;
+    });
+  }).catch(function(e) {
+    debug('Destroy failed:',e);
+    return callback(e,null);
+  });
+
+  return promise.then(resolved, callback);
+};
+
+/**
+ * Delete a model instance by id
+ */
+Couchbase.prototype.destroy = function destroy(model, id, callback) {
+};
+
+/**
+ * Update a model instance or create a new model instance if it doesn't exist
+ */
+Couchbase.prototype.updateOrCreate = function updateOrCreate(model, data, callback) {
+  console.log("updateOrCreate being used");
+};
+
+/**
+ * Find a model instance by id
+ */
+Couchbase.prototype.find = function find(model, id, callback) {
+  console.log("find being used");
 };
 
 /**
@@ -203,97 +343,13 @@ Couchbase.prototype.save = function (model, data, callback) {
  * Check if a model instance exists by id
  */
 Couchbase.prototype.exists = function (model, id, callback) {
-  var self = this;
-  debug("Couchbase.EXISTS: " + id);
-
-  if (callback == null) {
-    callback = noop;
-  }
-
-  // Handle with promise.
-  var promise;
-  var resolved = function(res) {
-    return callback(null, res);
-  };
-
-  promise = promise.then(function(bucket) {
-    bucket.get(id, function(err, result) {
-      if (err) {
-        debug('find exists failed');
-        return callback(err,null);
-      }
-      
-      debug('find exists successfully.');
-      return true;
-    });
-  });
-
-  return promise.then(resolved, callback);
-};
-
-/**
- * Find a model instance by id
- */
-Couchbase.prototype.find = function find(model, id, callback) {
-  var self = this;
-  debug("Couchbase.Find: " + id);
-
-  if (callback == null) {
-    callback = noop;
-  }
-
-  // Handle with promise.
-  var promise;
-  var resolved = function(res) {
-    return callback(null, res);
-  };
-
-  promise = promise.then(function(bucket) {
-    bucket.get(id, function(err, result) {
-      if (err) {
-        debug('Find failed');
-        return callback(err,null);
-      }
-      
-      debug('Find successfully.');
-      return result.value;
-    });
-  });
-
-  return promise.then(resolved, callback);
-};
-
-/**
- * Update a model instance or create a new model instance if it doesn't exist
- */
-Couchbase.prototype.updateOrCreate = function updateOrCreate(model, data, callback) {
-};
-
-/**
- * Delete a model instance by id
- */
-Couchbase.prototype.destroy = function destroy(model, id, callback) {
-};
-
-/**
- * Query model instances by the filter
- */
-Couchbase.prototype.all = function all(model, filter, callback) {
-  console.log("all being used.")
-};
-
-/**
- * Delete all model instances
- */
-Couchbase.prototype.destroyAll = function destroyAll(model, callback) {
-
 };
 
 /**
  * Count the model instances by the where criteria
  */
 Couchbase.prototype.count = function count(model, callback, where) {
-  console.log("count being used.")
+  console.log("count being used.");
 };
 
 /**

--- a/test/CRUD.test.js
+++ b/test/CRUD.test.js
@@ -1,0 +1,19 @@
+// This test written in mocha
+var should = require('./init.js');
+var db = getDataSource();
+
+describe('Couchbase CRUD methods', function() {
+  var Person = db.createModel('person', {id: {type: String, id: true}, name: String, age: Number});
+
+  it('create', function(done) {
+    Person.create({
+      id: 'asd',
+      name: 'Charlie',
+      age: 370
+    }, function(err, person) {
+      person.age.should.equal(370);
+      done(err, person);
+    });
+  });
+
+});

--- a/test/CRUD.test.js
+++ b/test/CRUD.test.js
@@ -16,4 +16,20 @@ describe('Couchbase CRUD methods', function() {
     });
   });
 
+  it('exists', function(done) {
+    Person.exists('asd', function(err, person) {
+      console.log(err);
+      customer.name.should.equal('Charlie');
+      done(err, person);
+    });
+  });
+
+  it('find', function(done) {
+    Person.find({id: 'asd'}, function(err, person) {
+      console.log(err);
+      customer.name.should.equal('Charlie');
+      done(err, person);
+    });
+  });
+
 });

--- a/test/CRUD.test.js
+++ b/test/CRUD.test.js
@@ -1,5 +1,6 @@
 // This test written in mocha
 var should = require('./init.js');
+var assert = require('assert');
 var db = getDataSource();
 
 describe('Couchbase CRUD methods', function() {
@@ -7,29 +8,62 @@ describe('Couchbase CRUD methods', function() {
 
   it('create', function(done) {
     Person.create({
-      id: 'asd',
+      id: '1',
       name: 'Charlie',
-      age: 370
+      age: 24
     }, function(err, person) {
-      person.age.should.equal(370);
-      done(err, person);
-    });
-  });
-
-  it('exists', function(done) {
-    Person.exists('asd', function(err, person) {
-      console.log(err);
-      customer.name.should.equal('Charlie');
+      person.age.should.equal(24);
       done(err, person);
     });
   });
 
   it('find', function(done) {
-    Person.find({id: 'asd'}, function(err, person) {
-      console.log(err);
-      customer.name.should.equal('Charlie');
+    Person.find({id: '1'}, function(err, person) {
+      person.name.should.equal('Charlie');
       done(err, person);
     });
   });
+
+  it('update', function(done) {
+    Person.update({
+      id: '1'
+    },{
+      id: '1',
+      name: 'Mary',
+      age: 37
+    }, function(err, res) {
+      assert.equal(res, true);
+      done(err, res);
+    });
+  });
+
+  it('destroy', function(done) {
+    Person.remove({
+      id: '1'
+    },function(err, res) {
+      assert.equal(res, true);
+      done(err, res);
+    });
+  });
+
+  // it('count', function(done) {
+  //   Person.count({id: 'asd'}, function(err, person) {
+  //     console.log(err);
+  //     console.log(JSON.stringify(person));//person.name.should.equal('Charlie');
+  //     done(err, person);
+  //   });
+  // });
+
+  // it('exists', function(done) {
+  //   Person.exists('asd', function(err, person) {
+  //     console.log(err);
+  //     person.name.should.equal('Charlie');
+  //     done(err, person);
+  //   });
+  // });
+
+  
+
+
 
 });

--- a/test/init.js
+++ b/test/init.js
@@ -1,8 +1,9 @@
 module.exports = require('should');
 
-function noop(err, res) {}
-
 var DataSource = require('loopback-datasource-juggler').DataSource;
+var ModelBuilder = require('loopback-datasource-juggler').ModelBuilder;
+
+function noop(err, res) {}
 
 var config = require('rc')('loopback', {
   test: {
@@ -33,9 +34,9 @@ global.getDataSource = global.getSchema = function(customConfig, callback) {
   if (callback == null) {
     callback = noop;
   }
-
+  var builder = new ModelBuilder();
   var db = new DataSource(require('../'), customConfig || config);
-  
+
   db.log = function(a) {
     console.log(a);
   };

--- a/test/init.js
+++ b/test/init.js
@@ -4,11 +4,28 @@ function noop(err, res) {}
 
 var DataSource = require('loopback-datasource-juggler').DataSource;
 
-var config = require('rc')('loopback', {test: {couchbase: {}}}).test.couchbase;
+var config = require('rc')('loopback', {
+  test: {
+    couchbase: {
+
+      //demo config
+      cluster:{
+        url:'couchbase://127.0.0.1',
+        options:{}
+      },
+      bucket:{
+        name:'default',
+        password:''
+      }
+
+    }
+  }
+}).test.couchbase;
 
 if (process.env.CI) {
   config = {
     // TODO
+
   };
 }
 
@@ -18,6 +35,7 @@ global.getDataSource = global.getSchema = function(customConfig, callback) {
   }
 
   var db = new DataSource(require('../'), customConfig || config);
+  
   db.log = function(a) {
     console.log(a);
   };


### PR DESCRIPTION
Hi @makara ,
I've added ```create``` method, I used ```('loopback-datasource-juggler').DataSource```'s ```createModel``` method to create models. But when tried to deploy ```count```, ```all``` and other methods, I found it difficult to find some examples just like how to deploy ```count``` and [document for CouchBase Node SDK](http://docs.couchbase.com/couchbase-sdk-node-1.2/) seemed not that clear.
- I've taken a look at [loopback-connector-couchbase](https://github.com/guardly/loopback-connector-couchbase), it uses its own clauseBuilder and dataBuilder to do most CRUD methods. Should I deploy ```N1QL``` first or any suggestions?
- I'm pretty new to ```promise``` way, I would appreciate if you have some time to review this code.

Thanks!