### PR TITLE
remove _cas property when converting to loopback data model

### DIFF
--- a/lib/couchbase3.js
+++ b/lib/couchbase3.js
@@ -375,6 +375,9 @@ class CouchbaseAccessor extends Accessor {
     if (data._type != null) {
       delete data._type;
     }
+    if (data._cas != null) {
+      delete data._cas;
+    }
     return data;
   }
 


### PR DESCRIPTION
After updating a property of a Loopback model instance and calling .save, the following error is passed to the callback:

ValidationError: The '<ModelName>' instance is not valid. Details: '_cas' is not defined in the model (value: undefined)

This PR removes `_cas` from the data object, along the same lines as the db-only `_type` property is removed.

#78 