### PR TITLE
fix: update lose _type field

### DIFF
--- a/lib/couchbaseX.js
+++ b/lib/couchbaseX.js
@@ -322,14 +322,12 @@ class CouchbaseAccessor extends Accessor {
    * Result is a promise with `[id, rev]` or an error.
    */
   putWithId(id, data, options) {
-    const blacklist = ['_type', '_cas'];
-    const update = {};
-    Object.keys(data).map(key => {
-      if (!blacklist.includes(key)) {
-        update[key] = data[key];
-      }
-    });
-    return this.connection.call('replaceAsync', id, update, options).then((res) => {
+    const record = Object.assign({}, data);
+    if ('_cas' in record) {
+      delete record._cas;
+    }
+
+    return this.connection.call('replaceAsync', id, record, options).then((res) => {
       return [id, res.cas];
     });
   }

--- a/test/cb.test.js
+++ b/test/cb.test.js
@@ -470,11 +470,10 @@ describe('Couchbase test', () => {
         const { value } = await connection.getAsync(record.id);
         value.should.have.property('name', record.name);
         value.should.not.have.property('_cas');
-        await Person.update({ id: record.id }, Object.assign({ _type: 'test' }, record));
+        await Person.update({ id: record.id }, record);
         const result = await connection.getAsync(record.id);
         const currentValue = result.value;
         currentValue.should.have.property('name', record.name);
-        currentValue.should.not.have.property('_type');
         currentValue.should.not.have.property('_cas');
         const people = await Person.findById(record.id);
         people.should.be.Object();


### PR DESCRIPTION
I make a mistake that the current update is `replace`. ` _type` can not be deleted. Add it back~!

@xavierchow 